### PR TITLE
Adding stepper without DIR pin

### DIFF
--- a/src/ESP_FlexyStepper.cpp
+++ b/src/ESP_FlexyStepper.cpp
@@ -248,8 +248,10 @@ void ESP_FlexyStepper::connectToPins(byte stepPinNumber, byte directionPinNumber
   // configure the IO pins
   pinMode(stepPin, OUTPUT);
   digitalWrite(stepPin, LOW);
-
-  pinMode(directionPin, OUTPUT);
+  
+  if(directionPin<255){
+	pinMode(directionPin, OUTPUT);
+	}
   digitalWrite(directionPin, LOW);
 }
 

--- a/src/ESP_FlexyStepper.h
+++ b/src/ESP_FlexyStepper.h
@@ -62,7 +62,7 @@ public:
   bool isStartedAsService(void);
 
   //IO setup and helper / debugging functions
-  void connectToPins(byte stepPinNumber, byte directionPinNumber);
+  void connectToPins(byte stepPinNumber, byte directionPinNumber=255);
   void setBrakePin(byte brakePin, byte activeState = ESP_FlexyStepper::ACTIVE_HIGH);
   long getTaskStackHighWaterMark(void);
   void clearLimitSwitchActive(void);


### PR DESCRIPTION
I took into account the contents of the file
### core \ packages \ framework-arduinoespressif32 \ cores \ esp32 \ esp32-hal-gpio.c
We'll assign the default DIR pin number 255:
`void connectToPins (byte stepPinNumber, byte directionPinNumber = 255);`

 For pinMode, a check is required because there is a code like this:
`uint32_t rtc_reg = rtc_gpio_desc [pin] .reg;`
where the rtc_gpio_desc array has only 40 cells, and our nonexistent pin is 255, so I added a check:
```
if (directionPin <255) {
pinMode (directionPin, OUTPUT);
}
```

We do not change the digitalWrite function in any way, because the value 255 will not be used in it:
```
extern void IRAM_ATTR __digitalWrite (uint8_t pin, uint8_t val)
{
    if (val) {
        if (pin <32) {
            GPIO.out_w1ts = ((uint32_t) 1 << pin);
        } else if (pin <34) {
            GPIO.out1_w1ts.val = ((uint32_t) 1 << (pin - 32));
        }
    } else {
        if (pin <32) {
            GPIO.out_w1tc = ((uint32_t) 1 << pin);
        } else if (pin <34) {
            GPIO.out1_w1tc.val = ((uint32_t) 1 << (pin - 32));
        }
    }
```