### PR TITLE
Adding core selection support

### DIFF
--- a/src/ESP_FlexyStepper.cpp
+++ b/src/ESP_FlexyStepper.cpp
@@ -93,19 +93,21 @@ ESP_FlexyStepper::~ESP_FlexyStepper()
 //TODO: use https://github.com/nrwiersma/ESP8266Scheduler/blob/master/examples/simple/simple.ino for ESP8266
 void ESP_FlexyStepper::startAsService(int core)
 {
- if(!core_0_wdt_was_disabled_from_flexyStepper){
+
+ if ( (!core_0_wdt_was_disabled_from_flexyStepper) && (core!=1) ) //If WDT has not been disabled previously and core 1 is not selected
+  {
 disableCore0WDT(); // we have to disable the Watchdog timer to prevent it from rebooting the ESP all the time another option would be to add a vTaskDelay but it would slow down the stepper
-core_0_wdt_was_disabled_from_flexyStepper=1;
+core_0_wdt_was_disabled_from_flexyStepper=1; //Let's indicate that we have disabled WDT for kernel 0
   }
   
-  xTaskCreateUniversal(
+  xTaskCreateUniversal(             //This type of task is specially adapted to work with single and dual core versions of ESP32
       ESP_FlexyStepper::taskRunner, /* Task function. */
       "FlexyStepper",               /* String with name of task (by default max 16 characters long) */
       2000,                         /* Stack size in bytes. */
       this,                         /* Parameter passed as input of the task */
       1,                            /* Priority of the task, 1 seems to work just fine for us */
-      &this->xHandle,              /* Task handle. */
-      core);                      /* Ядро, на котором будет выполняться задача */
+      &this->xHandle,               /* Task handle. */
+      core);                        /* The core on which our task will be executed*/
 }
 
 void ESP_FlexyStepper::taskRunner(void *parameter)

--- a/src/ESP_FlexyStepper.cpp
+++ b/src/ESP_FlexyStepper.cpp
@@ -91,21 +91,21 @@ ESP_FlexyStepper::~ESP_FlexyStepper()
 }
 
 //TODO: use https://github.com/nrwiersma/ESP8266Scheduler/blob/master/examples/simple/simple.ino for ESP8266
-void ESP_FlexyStepper::startAsService(bool core)
+void ESP_FlexyStepper::startAsService(int core)
 {
  if(!core_0_wdt_was_disabled_from_flexyStepper){
 disableCore0WDT(); // we have to disable the Watchdog timer to prevent it from rebooting the ESP all the time another option would be to add a vTaskDelay but it would slow down the stepper
 core_0_wdt_was_disabled_from_flexyStepper=1;
   }
   
-  xTaskCreatePinnedToCore(
+  xTaskCreateUniversal(
       ESP_FlexyStepper::taskRunner, /* Task function. */
       "FlexyStepper",               /* String with name of task (by default max 16 characters long) */
       2000,                         /* Stack size in bytes. */
       this,                         /* Parameter passed as input of the task */
       1,                            /* Priority of the task, 1 seems to work just fine for us */
       &this->xHandle,              /* Task handle. */
-      (int)core);                      /* Ядро, на котором будет выполняться задача */
+      core);                      /* Ядро, на котором будет выполняться задача */
 }
 
 void ESP_FlexyStepper::taskRunner(void *parameter)

--- a/src/ESP_FlexyStepper.cpp
+++ b/src/ESP_FlexyStepper.cpp
@@ -93,10 +93,9 @@ ESP_FlexyStepper::~ESP_FlexyStepper()
 //TODO: use https://github.com/nrwiersma/ESP8266Scheduler/blob/master/examples/simple/simple.ino for ESP8266
 void ESP_FlexyStepper::startAsService(bool core)
 {
-  if(core){
-disableCore1WDT(); // we have to disable the Watchdog timer to prevent it from rebooting the ESP all the time another option would be to add a vTaskDelay but it would slow down the stepper
-  }else{
+ if(!core_0_wdt_was_disabled_from_flexyStepper){
 disableCore0WDT(); // we have to disable the Watchdog timer to prevent it from rebooting the ESP all the time another option would be to add a vTaskDelay but it would slow down the stepper
+core_0_wdt_was_disabled_from_flexyStepper=1;
   }
   
   xTaskCreatePinnedToCore(

--- a/src/ESP_FlexyStepper.cpp
+++ b/src/ESP_FlexyStepper.cpp
@@ -91,16 +91,22 @@ ESP_FlexyStepper::~ESP_FlexyStepper()
 }
 
 //TODO: use https://github.com/nrwiersma/ESP8266Scheduler/blob/master/examples/simple/simple.ino for ESP8266
-void ESP_FlexyStepper::startAsService(void)
+void ESP_FlexyStepper::startAsService(bool core)
 {
-  disableCore0WDT(); // we have to disable the Watchdog timer to prevent it from rebooting the ESP all the time another option would be to add a vTaskDelay but it would slow down the stepper
-  xTaskCreate(
+  if(core){
+disableCore1WDT(); // we have to disable the Watchdog timer to prevent it from rebooting the ESP all the time another option would be to add a vTaskDelay but it would slow down the stepper
+  }else{
+disableCore0WDT(); // we have to disable the Watchdog timer to prevent it from rebooting the ESP all the time another option would be to add a vTaskDelay but it would slow down the stepper
+  }
+  
+  xTaskCreatePinnedToCore(
       ESP_FlexyStepper::taskRunner, /* Task function. */
       "FlexyStepper",               /* String with name of task (by default max 16 characters long) */
       2000,                         /* Stack size in bytes. */
       this,                         /* Parameter passed as input of the task */
       1,                            /* Priority of the task, 1 seems to work just fine for us */
-      &this->xHandle);              /* Task handle. */
+      &this->xHandle,              /* Task handle. */
+      (int)core);                      /* Ядро, на котором будет выполняться задача */
 }
 
 void ESP_FlexyStepper::taskRunner(void *parameter)

--- a/src/ESP_FlexyStepper.h
+++ b/src/ESP_FlexyStepper.h
@@ -59,7 +59,7 @@ public:
   ESP_FlexyStepper();
   ~ESP_FlexyStepper();
   //service functions
-  void startAsService(bool core=0);
+  void startAsService(int core= (-1) );
   void stopService(void);
   bool isStartedAsService(void);
 

--- a/src/ESP_FlexyStepper.h
+++ b/src/ESP_FlexyStepper.h
@@ -59,7 +59,7 @@ public:
   ESP_FlexyStepper();
   ~ESP_FlexyStepper();
   //service functions
-  void startAsService(int core= (-1) );
+  void startAsService(int core= (-1) ); //If the user does not specify the desired kernel as a parameter, then the free one will be selected
   void stopService(void);
   bool isStartedAsService(void);
 

--- a/src/ESP_FlexyStepper.h
+++ b/src/ESP_FlexyStepper.h
@@ -51,6 +51,8 @@
 typedef void (*callbackFunction)(void);
 typedef void (*positionCallbackFunction)(long);
 
+static bool core_0_wdt_was_disabled_from_flexyStepper = 0;
+
 class ESP_FlexyStepper
 {
 public:

--- a/src/ESP_FlexyStepper.h
+++ b/src/ESP_FlexyStepper.h
@@ -57,7 +57,7 @@ public:
   ESP_FlexyStepper();
   ~ESP_FlexyStepper();
   //service functions
-  void startAsService(void);
+  void startAsService(bool core=0);
   void stopService(void);
   bool isStartedAsService(void);
 


### PR DESCRIPTION
_Due to my poor knowledge of the English language, I did not add comments to the code._
I made two commits.
The first one adds the ability to specify the kernel for the background process
The second, when creating multiple instances of the process (several stepper motors), removes the message from Serial: `[E] [esp32-hal-misc.c: 94] disableCore0WDT (): Failed to remove Core 0 IDLE task from WDT`
It was not done very nicely, but I did not find a method to check if WDT is disabled or not.