### PR TITLE
Run targetPositionReachedCallback when moving 0 steps

### DIFF
--- a/src/ESP_FlexyStepper.cpp
+++ b/src/ESP_FlexyStepper.cpp
@@ -1347,6 +1347,16 @@ bool ESP_FlexyStepper::processMovement(void)
     else
     {
       this->lastStepDirectionBeforeLimitSwitchTrigger = 0;
+
+      if (this->firstProcessingAfterTargetReached)
+      {
+        firstProcessingAfterTargetReached = false;
+        if (this->_targetPositionReachedCallback)
+        {
+          this->_targetPositionReachedCallback(currentPosition_InSteps);
+        }
+      }
+
       // activate brake since motor is stopped
       if (this->_isBrakeConfigured && !this->_isBrakeActive && this->_hasMovementOccuredSinceLastBrakeRelease)
       {

--- a/src/ESP_FlexyStepper.h
+++ b/src/ESP_FlexyStepper.h
@@ -217,7 +217,7 @@ private:
   bool isCurrentlyHomed;
   bool isOnWayToHome = false;
   bool isOnWayToLimit = false;
-  bool firstProcessingAfterTargetReached = true;
+  bool firstProcessingAfterTargetReached = false;
   // The type ID of the limit switch type that is active. possible values are LIMIT_SWITCH_BEGIN (-1) or LIMIT_SWITCH_END (1) or LIMIT_SWITCH_COMBINED_BEGIN_AND_END (2) or 0 if no limit switch is active
   signed char activeLimitSwitch;
   bool limitSwitchCheckPeformed;


### PR DESCRIPTION
When doing a move that results in zero steps (for example by doing an absolute move with the same position twice), this makes sure that the callback for reaching the target position gets run.